### PR TITLE
Add pin_compatible run dependency for visit_struct

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: a9144816e79f517b52593d2d934d6e727ff136495fee3b37d3eb6ebaf892b355
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x.x') }}
 
@@ -26,6 +26,8 @@ requirements:
     - eigen
     - visit_struct
     - catch2
+  run:
+    - {{ pin_compatible('visit_struct', max_pin='x.x.x') }}
 
 test:
   commands:


### PR DESCRIPTION
visit_struct is an header only library, but it is used in the public interface of the compile `matio-cpp` library, so it can be influence its ABI, so we need to ensure that the user does not install a different version of visit_struct .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
